### PR TITLE
Fix "Consider an iterator instead of materializing the list" issue

### DIFF
--- a/jenkins_jobs/cmd.py
+++ b/jenkins_jobs/cmd.py
@@ -73,13 +73,13 @@ def recurse_path(root, excludes=None):
     for root, dirs, files in os.walk(basepath, topdown=True):
         dirs[:] = [
             d for d in dirs
-            if not any([fnmatch.fnmatch(d, pattern) for pattern in patterns])
-            if not any([fnmatch.fnmatch(os.path.abspath(os.path.join(root, d)),
+            if not any( fnmatch.fnmatch(d, pattern) for pattern in patterns)
+            if not any( fnmatch.fnmatch(os.path.abspath(os.path.join(root, d)),
                                         path)
-                        for path in absolute])
-            if not any([fnmatch.fnmatch(os.path.relpath(os.path.join(root, d)),
+                        for path in absolute)
+            if not any( fnmatch.fnmatch(os.path.relpath(os.path.join(root, d)),
                                         path)
-                        for path in relative])
+                        for path in relative)
         ]
         pathlist.extend([os.path.join(root, path) for path in dirs])
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider an iterator instead of materializing the list](https://www.quantifiedcode.com/app/issue_class/53lnAzfW)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:integration-jenkins-job-builder?groups=code_patterns/%3A53lnAzfW](https://www.quantifiedcode.com/app/project/gh:runt18:integration-jenkins-job-builder?groups=code_patterns/%3A53lnAzfW)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
