### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/jenkins_jobs/builder.py
+++ b/jenkins_jobs/builder.py
@@ -109,8 +109,8 @@ class CacheStorage(object):
                                    "exit: %s" % (self.cachefilename, e))
             else:
                 self._logger.info("Cache saved")
-                self._logger.debug("Cache written out to '%s'" %
-                                   self.cachefilename)
+                self._logger.debug("Cache written out to '{0!s}'".format(
+                                   self.cachefilename))
 
     def __del__(self):
         self.save()
@@ -305,7 +305,7 @@ class Builder(object):
             jobs = [jobs_glob]
 
         if jobs is not None:
-            logger.info("Removing jenkins job(s): %s" % ", ".join(jobs))
+            logger.info("Removing jenkins job(s): {0!s}".format(", ".join(jobs)))
         for job in jobs:
             self.jenkins.delete_job(job)
             if(self.cache.is_cached(job)):
@@ -342,7 +342,7 @@ class Builder(object):
 
         if (output and not hasattr(output, 'write')
                 and not os.path.isdir(output)):
-            logger.info("Creating directory %s" % output)
+            logger.info("Creating directory {0!s}".format(output))
             try:
                 os.makedirs(output)
             except OSError:

--- a/jenkins_jobs/cmd.py
+++ b/jenkins_jobs/cmd.py
@@ -54,7 +54,7 @@ send-as=Jenkins
 
 
 def confirm(question):
-    answer = input('%s (Y/N): ' % question).upper().strip()
+    answer = input('{0!s} (Y/N): '.format(question)).upper().strip()
     if not answer == 'Y':
         sys.exit('Aborted')
 
@@ -352,8 +352,8 @@ def execute(options, config):
 
 
 def version():
-    return "Jenkins Job Builder version: %s" % \
-        jenkins_jobs.version.version_info.version_string()
+    return "Jenkins Job Builder version: {0!s}".format( \
+        jenkins_jobs.version.version_info.version_string())
 
 
 if __name__ == '__main__':

--- a/jenkins_jobs/errors.py
+++ b/jenkins_jobs/errors.py
@@ -23,7 +23,7 @@ class ModuleError(JenkinsJobsException):
             # XML generation called via dispatch
             if co_name == 'dispatch':
                 data = frame.f_locals
-                module_name = "%s.%s" % (data['component_type'], data['name'])
+                module_name = "{0!s}.{1!s}".format(data['component_type'], data['name'])
                 break
             # XML generation done directly by class using gen_xml
             if co_name == 'gen_xml':

--- a/jenkins_jobs/formatter.py
+++ b/jenkins_jobs/formatter.py
@@ -41,7 +41,7 @@ def deep_format(obj, paramdict, allow_empty=False):
                 ret = CustomFormatter(allow_empty).format(obj, **paramdict)
         except KeyError as exc:
             missing_key = exc.message
-            desc = "%s parameter missing to format %s\nGiven:\n%s" % (
+            desc = "{0!s} parameter missing to format {1!s}\nGiven:\n{2!s}".format(
                 missing_key, obj, pformat(paramdict))
             raise JenkinsJobsException(desc)
     elif isinstance(obj, list):
@@ -56,7 +56,7 @@ def deep_format(obj, paramdict, allow_empty=False):
                     deep_format(obj[item], paramdict, allow_empty)
             except KeyError as exc:
                 missing_key = exc.message
-                desc = "%s parameter missing to format %s\nGiven:\n%s" % (
+                desc = "{0!s} parameter missing to format {1!s}\nGiven:\n{2!s}".format(
                     missing_key, obj, pformat(paramdict))
                 raise JenkinsJobsException(desc)
     else:

--- a/jenkins_jobs/local_yaml.py
+++ b/jenkins_jobs/local_yaml.py
@@ -128,7 +128,7 @@ class OrderedConstructor(BaseConstructor):
         else:
             raise yaml.constructor.ConstructorError(
                 None, None,
-                'expected a mapping node, but found %s' % node.id,
+                'expected a mapping node, but found {0!s}'.format(node.id),
                 node.start_mark)
 
         mapping = OrderedDict()
@@ -139,7 +139,7 @@ class OrderedConstructor(BaseConstructor):
             except TypeError as exc:
                 raise yaml.constructor.ConstructorError(
                     'while constructing a mapping', node.start_mark,
-                    'found unacceptable key (%s)' % exc, key_node.start_mark)
+                    'found unacceptable key ({0!s})'.format(exc), key_node.start_mark)
             value = self.construct_object(value_node, deep=False)
             mapping[key] = value
         data.update(mapping)

--- a/jenkins_jobs/modules/builders.py
+++ b/jenkins_jobs/modules/builders.py
@@ -249,7 +249,7 @@ def ant(parser, xml_parent, data):
             properties = data['properties']
             prop_string = ''
             for prop, val in properties.items():
-                prop_string += "%s=%s\n" % (prop, val)
+                prop_string += "{0!s}={1!s}\n".format(prop, val)
             prop_element = XML.SubElement(ant, 'properties')
             prop_element.text = prop_string
         if setting == 'java-opts':
@@ -1592,8 +1592,7 @@ def multijob(parser, xml_parent, data):
     condition = data.get('condition', 'SUCCESSFUL')
     conditions_available = ('SUCCESSFUL', 'UNSTABLE', 'COMPLETED', 'FAILURE')
     if condition not in conditions_available:
-        raise JenkinsJobsException('Multijob condition must be one of: %s.'
-                                   % ', '.join(conditions_available))
+        raise JenkinsJobsException('Multijob condition must be one of: {0!s}.'.format(', '.join(conditions_available)))
     XML.SubElement(builder, 'continuationCondition').text = condition
 
     phaseJobs = XML.SubElement(builder, 'phaseJobs')
@@ -1966,8 +1965,7 @@ def shining_panda(parser, xml_parent, data):
     if buildenv not in envs:
         raise InvalidAttributeError('build-environment', buildenv, envs)
 
-    t = XML.SubElement(xml_parent, '%s%s' %
-                       (pluginelementpart, buildenvdict[buildenv]))
+    t = XML.SubElement(xml_parent, '{0!s}{1!s}'.format(pluginelementpart, buildenvdict[buildenv]))
 
     if buildenv in ('python', 'virtualenv'):
         XML.SubElement(t, 'pythonName').text = data.get("python-version",
@@ -2314,7 +2312,7 @@ def ssh_builder(parser, xml_parent, data):
         XML.SubElement(builder, 'siteName').text = str(data['ssh-user-ip'])
         XML.SubElement(builder, 'command').text = str(data['command'])
     except KeyError as e:
-        raise MissingAttributeError("'%s'" % e.args[0])
+        raise MissingAttributeError("'{0!s}'".format(e.args[0]))
 
 
 def sonar(parser, xml_parent, data):

--- a/jenkins_jobs/modules/helpers.py
+++ b/jenkins_jobs/modules/helpers.py
@@ -79,8 +79,8 @@ def build_trends_publisher(plugin_name, xml_element, data):
                 config_value,
                 data.get('dont-compute-new', True))
         elif key == 'health-threshold' and config_value not in thresholds:
-            raise JenkinsJobsException("health-threshold must be one of %s" %
-                                       ", ".join(thresholds))
+            raise JenkinsJobsException("health-threshold must be one of {0!s}".format(
+                                       ", ".join(thresholds)))
         else:
             if isinstance(default, bool):
                 xml_config.text = str(config_value).lower()

--- a/jenkins_jobs/modules/notifications.py
+++ b/jenkins_jobs/modules/notifications.py
@@ -59,8 +59,8 @@ def http_endpoint(parser, xml_parent, data):
     format = data.get('format', 'JSON').upper()
     if format not in supported_formats:
         raise JenkinsJobsException(
-            "format must be one of %s" %
-            ", ".join(supported_formats))
+            "format must be one of {0!s}".format(
+            ", ".join(supported_formats)))
     else:
         XML.SubElement(endpoint_element, 'format').text = format
 
@@ -70,8 +70,8 @@ def http_endpoint(parser, xml_parent, data):
     event = data.get('event', 'all').lower()
     if event not in supported_events:
         raise JenkinsJobsException(
-            "event must be one of %s" %
-            ", ".join(supported_events))
+            "event must be one of {0!s}".format(
+            ", ".join(supported_events)))
     else:
         XML.SubElement(endpoint_element, 'event').text = event
 

--- a/jenkins_jobs/modules/project_matrix.py
+++ b/jenkins_jobs/modules/project_matrix.py
@@ -146,8 +146,7 @@ class Matrix(jenkins_jobs.modules.base.Base):
 
         if strategy not in self.supported_strategies:
             raise ValueError(
-                'Given strategy %s. Only %s strategies are supported'
-                % (strategy, self.supported_strategies.keys()))
+                'Given strategy {0!s}. Only {1!s} strategies are supported'.format(strategy, self.supported_strategies.keys()))
 
         ex_r = XML.SubElement(
             root, 'executionStrategy',
@@ -198,8 +197,7 @@ class Matrix(jenkins_jobs.modules.base.Base):
             axis = axis_['axis']
             axis_type = axis['type']
             if axis_type not in self.supported_axis:
-                raise ValueError('Only %s axes types are supported'
-                                 % self.supported_axis.keys())
+                raise ValueError('Only {0!s} axes types are supported'.format(self.supported_axis.keys()))
             axis_name = self.supported_axis.get(axis_type)
             lbl_root = XML.SubElement(ax_root, axis_name)
             name, values = axis.get('name', ''), axis.get('values', [''])

--- a/jenkins_jobs/modules/properties.py
+++ b/jenkins_jobs/modules/properties.py
@@ -362,7 +362,7 @@ def extended_choice(parser, xml_parent, data):
     `extended-choice` option in the parameter section of the job configuration
     instead.
     """
-    logger = logging.getLogger("%s:extended_choice" % __name__)
+    logger = logging.getLogger("{0!s}:extended_choice".format(__name__))
     logger.warn('Use of the extended-choice property is deprecated.  You '
                 'should use the extended-choice option in the parameter '
                 'section instead.')

--- a/jenkins_jobs/modules/publishers.py
+++ b/jenkins_jobs/modules/publishers.py
@@ -73,7 +73,7 @@ def archive(parser, xml_parent, data):
     .. literalinclude::  /../../tests/publishers/fixtures/archive001.yaml
        :language: yaml
     """
-    logger = logging.getLogger("%s:archive" % __name__)
+    logger = logging.getLogger("{0!s}:archive".format(__name__))
     archiver = XML.SubElement(xml_parent, 'hudson.tasks.ArtifactArchiver')
     artifacts = XML.SubElement(archiver, 'artifacts')
     artifacts.text = data['artifacts']
@@ -165,8 +165,7 @@ def jclouds(parser, xml_parent, data):
         XML.SubElement(deployer_entry, 'path').text = data.get('basedir', '')
         XML.SubElement(deployer_entry, 'sourceFile').text = data['files']
     except KeyError as e:
-        raise JenkinsJobsException("blobstore requires '%s' to be set"
-                                   % e.args[0])
+        raise JenkinsJobsException("blobstore requires '{0!s}' to be set".format(e.args[0]))
 
     XML.SubElement(deployer_entry, 'keepHierarchy').text = str(
         data.get('hierarchy', False)).lower()
@@ -522,8 +521,8 @@ def trigger(parser, xml_parent, data):
     threshold = data.get('threshold', 'SUCCESS')
     supported_thresholds = ['SUCCESS', 'UNSTABLE', 'FAILURE']
     if threshold not in supported_thresholds:
-        raise JenkinsJobsException("threshold must be one of %s" %
-                                   ", ".join(supported_thresholds))
+        raise JenkinsJobsException("threshold must be one of {0!s}".format(
+                                   ", ".join(supported_thresholds)))
     tname = XML.SubElement(tthreshold, 'name')
     tname.text = hudson_model.THRESHOLDS[threshold]['name']
     tordinal = XML.SubElement(tthreshold, 'ordinal')
@@ -1239,13 +1238,13 @@ def xunit(parser, xml_parent, data):
             logger.warn(
                 "Unrecognized threshold, should be 'failed' or 'skipped'")
             continue
-        elname = ("org.jenkinsci.plugins.xunit.threshold.%sThreshold" %
-                  next(iter(t.keys())).title())
+        elname = ("org.jenkinsci.plugins.xunit.threshold.{0!s}Threshold".format(
+                  next(iter(t.keys())).title()))
         el = XML.SubElement(xmlthresholds, elname)
         for threshold_name, threshold_value in next(iter(t.values())).items():
             # Normalize and craft the element name for this threshold
-            elname = "%sThreshold" % threshold_name.lower().replace(
-                'new', 'New')
+            elname = "{0!s}Threshold".format(threshold_name.lower().replace(
+                'new', 'New'))
             XML.SubElement(el, elname).text = str(threshold_value)
 
     # Whether to use percent of exact number of tests.
@@ -1849,8 +1848,7 @@ def email_ext(parser, xml_parent, data):
     }
     ctype = data.get('content-type', 'default')
     if ctype not in content_type_mime:
-        raise JenkinsJobsException('email-ext content type must be one of: %s'
-                                   % ', '.join(content_type_mime.keys()))
+        raise JenkinsJobsException('email-ext content type must be one of: {0!s}'.format(', '.join(content_type_mime.keys())))
     XML.SubElement(emailext, 'contentType').text = content_type_mime[ctype]
 
     XML.SubElement(emailext, 'defaultSubject').text = data.get(
@@ -2102,7 +2100,7 @@ def groovy_postbuild(parser, xml_parent, data):
         /../../tests/publishers/fixtures/groovy-postbuild001.yaml
        :language: yaml
     """
-    logger = logging.getLogger("%s:groovy-postbuild" % __name__)
+    logger = logging.getLogger("{0!s}:groovy-postbuild".format(__name__))
     # Backward compatibility with old format
     if isinstance(data, six.string_types):
         logger.warn(
@@ -2573,7 +2571,7 @@ def workspace_cleanup(parser, xml_parent, data):
         XML.SubElement(p, v).text = str(cdict.pop(k, True)).lower()
 
     if len(cdict) > 0:
-        raise ValueError('clean-if must be one of: %r' % list(mask.keys()))
+        raise ValueError('clean-if must be one of: {0!r}'.format(list(mask.keys())))
 
     if str(data.get("fail-build", False)).lower() == 'false':
         XML.SubElement(p, 'notFailBuild').text = 'true'
@@ -2852,8 +2850,8 @@ def rich_text_publisher(parser, xml_parent, data):
     parsers = ['HTML', 'Confluence', 'WikiText']
     parser_name = data['parser-name']
     if parser_name not in parsers:
-        raise JenkinsJobsException('parser-name must be one of: %s' %
-                                   ", ".join(parsers))
+        raise JenkinsJobsException('parser-name must be one of: {0!s}'.format(
+                                   ", ".join(parsers)))
 
     reporter = XML.SubElement(
         xml_parent,
@@ -3093,8 +3091,8 @@ def postbuildscript(parser, xml_parent, data):
         execute_on = data['execute-on'].lower()
         if execute_on not in valid_values:
             raise JenkinsJobsException(
-                'execute-on must be one of %s, got %s' %
-                valid_values, execute_on
+                'execute-on must be one of {0!s}, got {1!s}'.format(*
+                valid_values), execute_on
             )
         execute_on_xml = XML.SubElement(pbs_xml, 'executeOn')
         execute_on_xml.text = execute_on.upper()
@@ -3333,12 +3331,12 @@ def warnings(parser, xml_parent, data):
     XML.SubElement(warnings, 'thresholdLimit').text = prioritiesDict[priority]
     td = XML.SubElement(warnings, 'thresholds')
     for base in ["total", "new"]:
-        thresholds = data.get("%s-thresholds" % base, {})
+        thresholds = data.get("{0!s}-thresholds".format(base), {})
         for status in ["unstable", "failed"]:
             bystatus = thresholds.get(status, {})
             for level in ["all", "high", "normal", "low"]:
-                val = str(bystatus.get("%s-%s" % (base, level), ''))
-                XML.SubElement(td, "%s%s%s" % (status,
+                val = str(bystatus.get("{0!s}-{1!s}".format(base, level), ''))
+                XML.SubElement(td, "{0!s}{1!s}{2!s}".format(status,
                                base.capitalize(), level.capitalize())
                                ).text = val
     if data.get('new-thresholds'):
@@ -3600,7 +3598,7 @@ def plot(parser, xml_parent, data):
         XML.SubElement(plugin, 'title').text = plot.get('title', '')
         XML.SubElement(plugin, 'yaxis').text = plot['yaxis']
         XML.SubElement(plugin, 'csvFileName').text = \
-            plot.get('csv-file-name', '%s.csv' % random.randrange(2 << 32))
+            plot.get('csv-file-name', '{0!s}.csv'.format(random.randrange(2 << 32)))
         topseries = XML.SubElement(plugin, 'series')
         series = plot['series']
         for serie in series:
@@ -3735,7 +3733,7 @@ def git(parser, xml_parent, data):
             opt, xmlopt, default_val = prop[:3]
             val = entity.get(opt, default_val)
             if val is None:
-                raise JenkinsJobsException('Required option missing: %s' % opt)
+                raise JenkinsJobsException('Required option missing: {0!s}'.format(opt))
             if type(val) == bool:
                 val = str(val).lower()
             XML.SubElement(entity_xml, xmlopt).text = val
@@ -4283,11 +4281,11 @@ def valgrind(parser, xml_parent, data):
     for threshold in ['unstable', 'failed']:
         dthreshold = dthresholds.get(threshold, {})
         threshold = threshold.replace('failed', 'fail')
-        XML.SubElement(p, '%sThresholdInvalidReadWrite' % threshold).text \
+        XML.SubElement(p, '{0!s}ThresholdInvalidReadWrite'.format(threshold)).text \
             = str(dthreshold.get('invalid-read-write', ''))
-        XML.SubElement(p, '%sThresholdDefinitelyLost' % threshold).text \
+        XML.SubElement(p, '{0!s}ThresholdDefinitelyLost'.format(threshold)).text \
             = str(dthreshold.get('definitely-lost', ''))
-        XML.SubElement(p, '%sThresholdTotal' % threshold).text \
+        XML.SubElement(p, '{0!s}ThresholdTotal'.format(threshold)).text \
             = str(dthreshold.get('total', ''))
 
     XML.SubElement(p, 'failBuildOnMissingReports').text = str(
@@ -4553,8 +4551,8 @@ def downstream_ext(parser, xml_parent, data):
     criteria = data.get('criteria', 'success').upper()
 
     if criteria not in hudson_model.THRESHOLDS:
-        raise JenkinsJobsException("criteria must be one of %s" %
-                                   ", ".join(hudson_model.THRESHOLDS.keys()))
+        raise JenkinsJobsException("criteria must be one of {0!s}".format(
+                                   ", ".join(hudson_model.THRESHOLDS.keys())))
 
     wr_threshold = hudson_model.THRESHOLDS[
         criteria]
@@ -4566,8 +4564,8 @@ def downstream_ext(parser, xml_parent, data):
 
     condition = data.get('condition', 'equal-or-over')
     if condition not in conditions:
-        raise JenkinsJobsException('condition must be one of: %s' %
-                                   ", ".join(conditions))
+        raise JenkinsJobsException('condition must be one of: {0!s}'.format(
+                                   ", ".join(conditions)))
 
     XML.SubElement(p, 'thresholdStrategy').text = conditions[
         condition]
@@ -4731,8 +4729,8 @@ def conditional_publisher(parser, xml_parent, data):
             wr_name = cdata['condition-worst']
             if wr_name not in hudson_model.THRESHOLDS:
                 raise JenkinsJobsException(
-                    "threshold must be one of %s" %
-                    ", ".join(hudson_model.THRESHOLDS.keys()))
+                    "threshold must be one of {0!s}".format(
+                    ", ".join(hudson_model.THRESHOLDS.keys())))
             wr_threshold = hudson_model.THRESHOLDS[wr_name]
             XML.SubElement(wr, "name").text = wr_threshold['name']
             XML.SubElement(wr, "ordinal").text = wr_threshold['ordinal']
@@ -4744,8 +4742,8 @@ def conditional_publisher(parser, xml_parent, data):
             br_name = cdata['condition-best']
             if br_name not in hudson_model.THRESHOLDS:
                 raise JenkinsJobsException(
-                    "threshold must be one of %s" %
-                    ", ".join(hudson_model.THRESHOLDS.keys()))
+                    "threshold must be one of {0!s}".format(
+                    ", ".join(hudson_model.THRESHOLDS.keys())))
             br_threshold = hudson_model.THRESHOLDS[br_name]
             XML.SubElement(br, "name").text = br_threshold['name']
             XML.SubElement(br, "ordinal").text = br_threshold['ordinal']
@@ -5345,8 +5343,8 @@ def flowdock(parser, xml_parent, data):
             data.get(data_item, default)).lower()
 
     def gen_setting(item, default):
-        XML.SubElement(parent, 'notify%s' % item).text = str(
-            data.get('notify-%s' % item.lower(), default)).lower()
+        XML.SubElement(parent, 'notify{0!s}'.format(item)).text = str(
+            data.get('notify-{0!s}'.format(item.lower()), default)).lower()
 
     # Raise exception if token was not specified
     if 'token' not in data:

--- a/jenkins_jobs/modules/scm.py
+++ b/jenkins_jobs/modules/scm.py
@@ -188,7 +188,7 @@ def git(parser, xml_parent, data):
         https://www.visualstudio.com/en-us/products/tfs-overview-vs.aspx
 
     """
-    logger = logging.getLogger("%s:git" % __name__)
+    logger = logging.getLogger("{0!s}:git".format(__name__))
 
     # XXX somebody should write the docs for those with option name =
     # None so we have a sensible name/key for it.
@@ -276,8 +276,8 @@ def git(parser, xml_parent, data):
         choosing_strategy = choosing_strategies[data.get('choosing-strategy',
                                                          'default')]
     except KeyError:
-        raise ValueError('Invalid choosing-strategy %r' %
-                         data.get('choosing-strategy'))
+        raise ValueError('Invalid choosing-strategy {0!r}'.format(
+                         data.get('choosing-strategy')))
     XML.SubElement(scm, 'buildChooser', {'class': choosing_strategy})
 
     for elem in mapping:
@@ -1027,8 +1027,8 @@ def hg(self, xml_parent, data):
     try:
         revision_type = revision_type_dict[data.get('revision-type', 'branch')]
     except KeyError:
-        raise JenkinsJobsException('Invalid revision-type %r' %
-                                   data.get('revision-type'))
+        raise JenkinsJobsException('Invalid revision-type {0!r}'.format(
+                                   data.get('revision-type')))
     XML.SubElement(scm, 'revisionType').text = revision_type
 
     XML.SubElement(scm, 'revision').text = data.get('revision', 'default')

--- a/jenkins_jobs/modules/triggers.py
+++ b/jenkins_jobs/modules/triggers.py
@@ -51,7 +51,7 @@ def gerrit_handle_legacy_configuration(data):
     def hyphenize(attr):
         """Convert strings like triggerOn to trigger-on.
         """
-        return hyphenizer.sub(lambda x: "-%s" % x.group(0).lower(),
+        return hyphenizer.sub(lambda x: "-{0!s}".format(x.group(0).lower()),
                               attr)
 
     def convert_dict(d, old_keys):
@@ -146,13 +146,13 @@ def build_gerrit_triggers(xml_parent, data):
                        "known: %s.") % (event, known)
                 raise JenkinsJobsException(msg)
             XML.SubElement(trigger_on_events,
-                           '%s.%s' % (tag_namespace, tag_name))
+                           '{0!s}.{1!s}'.format(tag_namespace, tag_name))
         else:
             if 'patchset-created-event' in event.keys():
                 pce = event['patchset-created-event']
                 pc = XML.SubElement(
                     trigger_on_events,
-                    '%s.%s' % (tag_namespace, 'PluginPatchsetCreatedEvent'))
+                    '{0!s}.{1!s}'.format(tag_namespace, 'PluginPatchsetCreatedEvent'))
                 XML.SubElement(pc, 'excludeDrafts').text = str(
                     pce.get('exclude-drafts', False)).lower()
                 XML.SubElement(pc, 'excludeTrivialRebase').text = str(
@@ -164,7 +164,7 @@ def build_gerrit_triggers(xml_parent, data):
                 comment_added_event = event['comment-added-event']
                 cadded = XML.SubElement(
                     trigger_on_events,
-                    '%s.%s' % (tag_namespace, 'PluginCommentAddedEvent'))
+                    '{0!s}.{1!s}'.format(tag_namespace, 'PluginCommentAddedEvent'))
                 XML.SubElement(cadded, 'verdictCategory').text = \
                     comment_added_event['approval-category']
                 XML.SubElement(
@@ -176,7 +176,7 @@ def build_gerrit_triggers(xml_parent, data):
                 comment_added_event = event['comment-added-contains-event']
                 caddedc = XML.SubElement(
                     trigger_on_events,
-                    '%s.%s' % (tag_namespace,
+                    '{0!s}.{1!s}'.format(tag_namespace,
                                'PluginCommentAddedContainsEvent'))
                 XML.SubElement(caddedc, 'commentAddedCommentContains').text = \
                     comment_added_event['comment-contains-value']
@@ -739,9 +739,8 @@ def pollurl(parser, xml_parent, data):
         for entry in check_content:
             type_name = next(iter(entry.keys()))
             if type_name not in valid_content_types:
-                raise JenkinsJobsException('check-content must be one of : %s'
-                                           % ', '.join(valid_content_types.
-                                                       keys()))
+                raise JenkinsJobsException('check-content must be one of : {0!s}'.format(', '.join(valid_content_types.
+                                                       keys())))
 
             content_type = valid_content_types.get(type_name)
             if entry[type_name]:
@@ -1203,8 +1202,8 @@ def reverse(parser, xml_parent, data):
     result = str(data.get('result', 'success')).upper()
     if result not in supported_thresholds:
         raise jenkins_jobs.errors.JenkinsJobsException(
-            "Choice should be one of the following options: %s." %
-            ", ".join(supported_thresholds))
+            "Choice should be one of the following options: {0!s}.".format(
+            ", ".join(supported_thresholds)))
     XML.SubElement(threshold, 'name').text = \
         hudson_model.THRESHOLDS[result]['name']
     XML.SubElement(threshold, 'ordinal').text = \

--- a/jenkins_jobs/modules/wrappers.py
+++ b/jenkins_jobs/modules/wrappers.py
@@ -685,7 +685,7 @@ def copy_to_slave(parser, xml_parent, data):
     rel = str(data.get('relative-to', 'userContent'))
     opt = ('home', 'somewhereElse', 'userContent', 'workspace')
     if rel not in opt:
-        raise ValueError('relative-to must be one of %r' % opt)
+        raise ValueError('relative-to must be one of {0!r}'.format(opt))
     XML.SubElement(cs, 'relativeTo').text = rel
 
     # seems to always be false, can't find it in source code
@@ -1431,8 +1431,8 @@ def credentials_binding(parser, xml_parent, data):
     for binding in data:
         for binding_type, params in binding.items():
             if binding_type not in binding_types.keys():
-                raise JenkinsJobsException('binding-type must be one of %r' %
-                                           binding_types.keys())
+                raise JenkinsJobsException('binding-type must be one of {0!r}'.format(
+                                           binding_types.keys()))
 
             binding_xml = XML.SubElement(bindings_xml,
                                          binding_types[binding_type])

--- a/jenkins_jobs/registry.py
+++ b/jenkins_jobs/registry.py
@@ -184,8 +184,8 @@ class ModuleRegistry(object):
                     # extract entry point based on docstring
                     name_line = func_ep.__doc__.split('\n')
                     if not name_line[0].startswith('yaml:'):
-                        logger.debug("Ignoring '%s' as an entry point" %
-                                     name_line)
+                        logger.debug("Ignoring '{0!s}' as an entry point".format(
+                                     name_line))
                         continue
                     ep_name = name_line[0].split(' ')[1]
                 except (AttributeError, IndexError):
@@ -193,8 +193,7 @@ class ModuleRegistry(object):
                     # a string to have split called on it.
                     # IndexError raised by name_line not containing anything
                     # after the 'yaml:' string.
-                    logger.debug("Not including func '%s' as an entry point"
-                                 % func_ep.__name__)
+                    logger.debug("Not including func '{0!s}' as an entry point".format(func_ep.__name__))
                     continue
 
                 module_eps.append(
@@ -202,8 +201,7 @@ class ModuleRegistry(object):
                         ep_name, entry_point.module_name,
                         dist=entry_point.dist, attrs=(func_ep.__name__,)))
                 logger.debug(
-                    "Adding auto EP '%s=%s:%s'" %
-                    (ep_name, entry_point.module_name, func_ep.__name__))
+                    "Adding auto EP '{0!s}={1!s}:{2!s}'".format(ep_name, entry_point.module_name, func_ep.__name__))
 
             # load from explicitly defined entry points
             module_eps.extend(list(pkg_resources.iter_entry_points(

--- a/tests/base.py
+++ b/tests/base.py
@@ -121,8 +121,8 @@ class BaseTestCase(LoggingFixture):
             return u""
 
         # Read XML content, assuming it is unicode encoded
-        xml_content = u"%s" % io.open(self.out_filename,
-                                      'r', encoding='utf-8').read()
+        xml_content = u"{0!s}".format(io.open(self.out_filename,
+                                      'r', encoding='utf-8').read())
         return xml_content
 
     def _read_yaml_content(self, filename):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:integration-jenkins-job-builder?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:integration-jenkins-job-builder?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
